### PR TITLE
fix: reference slug path in for rockcraft.yaml

### DIFF
--- a/rockcraft/models/project.py
+++ b/rockcraft/models/project.py
@@ -437,7 +437,7 @@ class Project(BaseProject):
     @override
     @classmethod
     def model_reference_slug(cls) -> str | None:
-        return "/reference/rockcraft.yaml"
+        return "/reference/rockcraft-yaml"
 
     @pydantic.field_validator("platforms")
     @classmethod


### PR DESCRIPTION
The existing CLI messages provide the wrong link to the users:
Example:

```
Bad rockcraft.yaml content:
...
For more information, check out: https://documentation.ubuntu.com/rockcraft/latest/reference/rockcraft.yaml
```
---

- [x] I've followed the [contribution guidelines](https://github.com/canonical/rockcraft/blob/main/CONTRIBUTING.md).
- [x] I've signed the [CLA](http://www.ubuntu.com/legal/contributors/).
- [ ] I've successfully run `make lint && make test`.
- [ ] I've added or updated any relevant documentation.
